### PR TITLE
CR-000-007: isolate compose projects and data roots

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,5 +1,6 @@
 IMAGE_TAG=dev
-DATA_ROOT=/srv/mnemosyne/dev
+COMPOSE_PROJECT_NAME=mnemosyne-dev
+DATA_ROOT=/home/tgrytnes/projects/Mnemosyne/data/dev
 
 WEAVIATE_HOST_PORT=8082
 WEAVIATE_GRPC_HOST_PORT=50062
@@ -22,7 +23,7 @@ NEO4J_USER=neo4j
 NEO4J_PASSWORD=CHANGE_ME
 
 OLLAMA_BASE_URL=http://host.docker.internal:11434
-SOURCE_DIR=/srv/mnemosyne/dev/emails
+SOURCE_DIR=/home/tgrytnes/projects/Mnemosyne/data/dev/emails
 
 SCHEDULER_INTERVAL_HOURS=24
 N_CLUSTERS=50

--- a/.env.prod
+++ b/.env.prod
@@ -1,5 +1,6 @@
 IMAGE_TAG=CHANGE_ME
-DATA_ROOT=/srv/mnemosyne/prod
+COMPOSE_PROJECT_NAME=mnemosyne-prod
+DATA_ROOT=/home/tgrytnes/projects/Mnemosyne/data/prod
 
 WEAVIATE_HOST_PORT=8083
 WEAVIATE_GRPC_HOST_PORT=50063
@@ -22,7 +23,7 @@ NEO4J_USER=neo4j
 NEO4J_PASSWORD=CHANGE_ME
 
 OLLAMA_BASE_URL=http://host.docker.internal:11434
-SOURCE_DIR=/srv/mnemosyne/prod/emails
+SOURCE_DIR=/home/tgrytnes/projects/Mnemosyne/data/prod/emails
 
 SCHEDULER_INTERVAL_HOURS=24
 N_CLUSTERS=50

--- a/.env.staging
+++ b/.env.staging
@@ -1,5 +1,6 @@
 IMAGE_TAG=CHANGE_ME
-DATA_ROOT=/srv/mnemosyne/staging
+COMPOSE_PROJECT_NAME=mnemosyne-staging
+DATA_ROOT=/home/tgrytnes/projects/Mnemosyne/data/staging
 
 WEAVIATE_HOST_PORT=8081
 WEAVIATE_GRPC_HOST_PORT=50061
@@ -23,7 +24,7 @@ NEO4J_PASSWORD=CHANGE_ME
 
 OLLAMA_BASE_URL=http://host.docker.internal:11434
 
-SOURCE_DIR=/srv/mnemosyne/staging/emails
+SOURCE_DIR=/home/tgrytnes/projects/Mnemosyne/data/staging/emails
 
 SCHEDULER_INTERVAL_HOURS=24
 N_CLUSTERS=50

--- a/scripts/refresh-stack.sh
+++ b/scripts/refresh-stack.sh
@@ -6,7 +6,7 @@ STACK="${1:-dev}"
 
 usage() {
   cat <<EOF
-Usage: $0 [dev|staging]
+Usage: $0 [dev|staging|prod]
 Pulls the latest image for the chosen stack (defaults to dev), refreshes the compose stack,
 and stops the Mnemosyne daemon processes so you can restart them cleanly afterward.
 EOF
@@ -21,6 +21,10 @@ dev)
 staging)
   ENV_FILE="$ROOT_DIR/.env.staging"
   COMPOSE_FILES=(-f "$ROOT_DIR/docker-compose.yml" -f "$ROOT_DIR/docker-compose.staging.yml")
+  ;;
+prod)
+  ENV_FILE="$ROOT_DIR/.env.prod"
+  COMPOSE_FILES=(-f "$ROOT_DIR/docker-compose.yml" -f "$ROOT_DIR/docker-compose.prod.yml")
   ;;
 *)
   usage
@@ -76,6 +80,13 @@ elif [[ -n "$RUNTIME_IMAGE_TAG" ]]; then
 else
   export IMAGE_TAG="latest"
 fi
+
+if [[ -z "${COMPOSE_PROJECT_NAME:-}" ]]; then
+  COMPOSE_PROJECT_NAME="mnemosyne-${STACK}"
+  echo "COMPOSE_PROJECT_NAME not set; defaulting to $COMPOSE_PROJECT_NAME"
+fi
+export COMPOSE_PROJECT_NAME
+echo "Using COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME"
 
 echo "Refreshing the $STACK stack with IMAGE_TAG=$IMAGE_TAG..."
 compose down --remove-orphans

--- a/tests/unit/test_environment_isolation.py
+++ b/tests/unit/test_environment_isolation.py
@@ -1,0 +1,44 @@
+"""Unit tests for environment isolation config (compose project + data roots)."""
+
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _env_text(name: str) -> str:
+    return (_repo_root() / f".env.{name}").read_text(encoding="utf-8")
+
+
+def test_env_files_define_compose_project_name():
+    for name in ("dev", "staging", "prod"):
+        content = _env_text(name)
+        assert "COMPOSE_PROJECT_NAME=" in content
+
+
+def test_env_files_use_expected_data_root_paths():
+    expected = {
+        "dev": "/home/tgrytnes/projects/Mnemosyne/data/dev",
+        "staging": "/home/tgrytnes/projects/Mnemosyne/data/staging",
+        "prod": "/home/tgrytnes/projects/Mnemosyne/data/prod",
+    }
+    for name, path in expected.items():
+        content = _env_text(name)
+        assert f"DATA_ROOT={path}" in content
+
+
+def test_env_compose_files_avoid_fixed_container_names():
+    repo_root = _repo_root()
+    compose_files = [
+        "docker-compose.yml",
+        "docker-compose.dev.yml",
+        "docker-compose.staging.yml",
+        "docker-compose.prod.yml",
+    ]
+    for filename in compose_files:
+        path = repo_root / filename
+        if not path.exists():
+            continue
+        content = path.read_text(encoding="utf-8")
+        assert "container_name:" not in content

--- a/tests/unit/test_refresh_stack_script.py
+++ b/tests/unit/test_refresh_stack_script.py
@@ -42,6 +42,11 @@ def test_refresh_stack_uses_runtime_tag_snapshot():
     assert "RUNTIME_IMAGE_TAG" in content
 
 
+def test_refresh_stack_supports_prod_stack():
+    content = _script_text()
+    assert "prod" in content
+
+
 def test_refresh_stack_reports_container_status():
     content = _script_text()
     assert "docker compose" in content
@@ -52,3 +57,8 @@ def test_refresh_stack_checks_watcher_processes_in_containers():
     content = _script_text()
     assert "docker exec" in content
     assert "pgrep" in content
+
+
+def test_refresh_stack_uses_compose_project_name():
+    content = _script_text()
+    assert "COMPOSE_PROJECT_NAME" in content

--- a/user-stories/STORY_INDEX.md
+++ b/user-stories/STORY_INDEX.md
@@ -24,6 +24,7 @@ Quick reference for all user stories with status tracking.
 | CR-000-004 | Unique Host Ports per Environment | High | 3-5 pts | 📝 Draft | - |
 | CR-000-005 | E2E Ingestion Progress Logging & Reduced Test Load | High | 1-2 pts | 📝 Draft | - |
 | CR-000-006 | Scheduler/Ingestor Operational Controls | High | 3-5 pts | 🔄 In Progress | - |
+| CR-000-007 | Compose Project + Data Isolation for Dev/Staging/Prod | High | 3-5 pts | 📝 Draft | - |
 
 Note: CR-000-003 updated to include per-environment data directories and optional .env.<env>.local overrides (2026-01-05).
 

--- a/user-stories/phase-0-ingestion-hygiene/CR-000-007-compose-project-isolation.md
+++ b/user-stories/phase-0-ingestion-hygiene/CR-000-007-compose-project-isolation.md
@@ -1,0 +1,47 @@
+# CR-000-007: Compose Project + Data Isolation for Dev/Staging/Prod
+
+**As a** platform operator  
+**I want** dev, staging, and prod to run as fully isolated systems with separate compose project names and data roots  
+**So that** all three can run concurrently without port or data conflicts.
+
+## Excellent Acceptance Criteria
+
+- [ ] **Scenario: Distinct compose projects**
+  - **Given** `.env.dev`, `.env.staging`, and `.env.prod`
+  - **When** each stack is started
+  - **Then** each uses a unique `COMPOSE_PROJECT_NAME` (`mnemosyne-dev`, `mnemosyne-staging`, `mnemosyne-prod`), creating separate networks and container names.
+
+- [ ] **Scenario: No container_name collisions**
+  - **Given** the compose files
+  - **When** stacks are started concurrently
+  - **Then** there are no fixed `container_name` values that would collide across environments.
+
+- [ ] **Scenario: Isolated data roots**
+  - **Given** `DATA_ROOT` is set per environment
+  - **When** the stack starts
+  - **Then** all host-mounted data paths resolve under:
+    - `/home/tgrytnes/projects/Mnemosyne/data/dev`
+    - `/home/tgrytnes/projects/Mnemosyne/data/staging`
+    - `/home/tgrytnes/projects/Mnemosyne/data/prod`
+
+- [ ] **Scenario: Data migration for dev and staging**
+  - **Given** existing shared data directories
+  - **When** this CR is applied
+  - **Then** dev and staging data are migrated into their new `DATA_ROOT` locations
+  - **And** prod remains empty by default.
+
+- [ ] **Scenario: Ports remain unique**
+  - **Given** the current port mappings
+  - **When** dev, staging, and prod run simultaneously
+  - **Then** no host port conflicts occur.
+
+- [ ] **Scenario: Refresh-stack honors environment isolation**
+  - **Given** `scripts/refresh-stack.sh` is run for any environment
+  - **When** the stack is refreshed
+  - **Then** it uses that environment's `COMPOSE_PROJECT_NAME` and `DATA_ROOT` values.
+
+## Testing Plan
+
+- Unit: refresh-stack env resolution uses `COMPOSE_PROJECT_NAME` and `DATA_ROOT`.
+- Integration: start dev + staging simultaneously; confirm distinct container names, networks, and volumes.
+- E2E: run refresh-stack for dev, staging, prod sequentially; confirm each stack healthy and data paths isolated.


### PR DESCRIPTION
## Summary\n- add COMPOSE_PROJECT_NAME per env and update DATA_ROOT paths\n- add prod support + project name logging in refresh-stack.sh\n- add unit coverage for env isolation and script updates\n- document CR-000-007 and update story index\n\n## Testing\n- ./.venv/bin/python -m pytest tests/unit/test_refresh_stack_script.py tests/unit/test_environment_isolation.py\n- ./.venv/bin/black tests/unit/test_environment_isolation.py tests/unit/test_refresh_stack_script.py\n- ./.venv/bin/ruff check tests/unit/test_environment_isolation.py tests/unit/test_refresh_stack_script.py\n\nCloses #80