### PR TITLE
Hotfix: skip missing vectors in clustering

### DIFF
--- a/src/mnemosyne/cli/cluster.py
+++ b/src/mnemosyne/cli/cluster.py
@@ -61,14 +61,28 @@ class ClusterManager:
         logger.info("Fetching all vectors from %s collection...", self.collection_name)
         vectors = []
         uuids = []
+        skipped = 0
 
         query_result = self.collection.iterator(include_vector=True)
 
         for item in query_result:
-            vectors.append(item.vector["default"])
+            vector = item.vector
+            default_vector = None
+            if isinstance(vector, dict):
+                default_vector = vector.get("default")
+            elif vector is not None:
+                default_vector = vector
+
+            if not default_vector:
+                skipped += 1
+                continue
+
+            vectors.append(default_vector)
             uuids.append(str(item.uuid))
 
-        logger.info(f"Fetched {len(vectors)} vectors.")
+        if skipped:
+            logger.warning("Skipped %s objects without default vectors.", skipped)
+        logger.info("Fetched %s vectors.", len(vectors))
         return np.array(vectors), uuids
 
     def run_kmeans_clustering(

--- a/tests/unit/test_cluster_manager.py
+++ b/tests/unit/test_cluster_manager.py
@@ -1,0 +1,49 @@
+"""Unit tests for ClusterManager vector handling."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mnemosyne.cli.cluster import ClusterManager
+
+
+class _FakeItem:
+    def __init__(self, uuid: str, vector):
+        self.uuid = uuid
+        self.vector = vector
+
+
+class _FakeCollection:
+    def __init__(self, items):
+        self._items = items
+
+    def iterator(self, include_vector: bool = False):
+        return iter(self._items)
+
+
+class _FakeCollections:
+    def __init__(self, collection):
+        self._collection = collection
+
+    def get(self, _name: str):
+        return self._collection
+
+
+class _FakeClient:
+    def __init__(self, collection):
+        self.collections = _FakeCollections(collection)
+
+
+def test_fetch_all_vectors_skips_missing_default(caplog):
+    items = [
+        _FakeItem("uuid-1", {"default": [0.1, 0.2]}),
+        _FakeItem("uuid-2", {}),
+        _FakeItem("uuid-3", {"default": [0.3, 0.4]}),
+    ]
+    manager = ClusterManager(_FakeClient(_FakeCollection(items)))
+
+    vectors, uuids = manager.fetch_all_vectors()
+
+    assert uuids == ["uuid-1", "uuid-3"]
+    assert np.allclose(vectors, np.array([[0.1, 0.2], [0.3, 0.4]]))
+    assert any("skipped" in record.message.lower() for record in caplog.records)


### PR DESCRIPTION
## Summary\n- skip objects without a default vector to avoid KeyError in clustering\n- log skipped count\n- add unit test for missing vectors\n\n## Testing\n- pytest tests/unit/test_cluster_manager.py -v\n