### PR TITLE
Hotfix: skip inserts when embeddings fail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - Before development, ensure the user story is absolutely clear.
 - Ensure acceptance criteria are excellent and complete.
 - Ensure test coverage plan is excellent (unit + integration + e2e).
+- When writing GitHub issues, use proper Markdown with real newlines (no escaped `\\n`).
 - Quality Gate #1: begin test or implementation work only after the above is completed and explicitly approved by the user.
 
 ## Test Quality Gate

--- a/src/mnemosyne/aletheia/email_ingest.py
+++ b/src/mnemosyne/aletheia/email_ingest.py
@@ -183,6 +183,9 @@ class EmailIngestor:
                 rejected += 1
                 continue
 
+            chunk_embeddings: list[tuple[EmailChunk, list[float]]] = []
+            failed_embedding = False
+
             for chunk in chunks:
                 if not chunk.text.strip():
                     continue
@@ -196,7 +199,34 @@ class EmailIngestor:
                     parent_source_path=email.source_path,
                 )
 
-                vec = self.embedder(chunk_item.chunk_text)
+                try:
+                    vec = self.embedder(chunk_item.chunk_text)
+                except Exception as exc:
+                    logger.error(
+                        "Embedding failed for %s chunk %s: %s",
+                        chunk_item.parent_source_path,
+                        chunk_item.chunk_index,
+                        exc,
+                    )
+                    failed_embedding = True
+                    break
+
+                if not vec:
+                    logger.error(
+                        "Embedding empty for %s chunk %s",
+                        chunk_item.parent_source_path,
+                        chunk_item.chunk_index,
+                    )
+                    failed_embedding = True
+                    break
+
+                chunk_embeddings.append((chunk_item, vec))
+
+            if failed_embedding or not chunk_embeddings:
+                rejected += 1
+                continue
+
+            for chunk_item, vec in chunk_embeddings:
                 props = {
                     "subject": chunk_item.parent_subject,
                     "body": chunk_item.chunk_text,

--- a/src/mnemosyne/aletheia/obsidian_ingestor.py
+++ b/src/mnemosyne/aletheia/obsidian_ingestor.py
@@ -161,8 +161,24 @@ class ObsidianIngestor:
                 return 0
 
             self._delete_existing_chunks(file_path)
+            inserted_chunks = 0
+            failed_embedding = False
             for chunk in chunks:
-                embedding = self._generate_embedding(chunk.text)
+                try:
+                    embedding = self._generate_embedding(chunk.text)
+                except Exception as exc:
+                    logger.error(
+                        "Embedding failed for %s chunk %s: %s",
+                        file_path,
+                        chunk.index,
+                        exc,
+                    )
+                    failed_embedding = True
+                    continue
+                if not embedding:
+                    logger.error("Embedding empty for %s chunk %s", file_path, chunk.index)
+                    failed_embedding = True
+                    continue
                 self._store_chunk(
                     {
                         "text": chunk.text,
@@ -176,10 +192,15 @@ class ObsidianIngestor:
                         "embedding": embedding,
                     }
                 )
+                inserted_chunks += 1
 
-            self.state_tracker.mark_ingested(file_path, mod_time, len(chunks))
-            logger.info(f"Ingested {file_path}: {len(chunks)} chunks")
-            return len(chunks)
+            if not failed_embedding:
+                self.state_tracker.mark_ingested(file_path, mod_time, inserted_chunks)
+            else:
+                logger.error("Embedding failures detected for %s; skipping state update", file_path)
+
+            logger.info(f"Ingested {file_path}: {inserted_chunks} chunks")
+            return inserted_chunks
         except Exception as e:
             logger.error(f"Error ingesting {file_path}: {e}")
             return 0
@@ -224,8 +245,24 @@ class ObsidianIngestor:
         total_to_process = len(prepared_files)
         for index, (file_path, mod_time, chunks) in enumerate(prepared_files, start=1):
             self._delete_existing_chunks(file_path)
+            inserted_chunks = 0
+            failed_embedding = False
             for chunk in chunks:
-                embedding = self._generate_embedding(chunk.text)
+                try:
+                    embedding = self._generate_embedding(chunk.text)
+                except Exception as exc:
+                    logger.error(
+                        "Embedding failed for %s chunk %s: %s",
+                        file_path,
+                        chunk.index,
+                        exc,
+                    )
+                    failed_embedding = True
+                    continue
+                if not embedding:
+                    logger.error("Embedding empty for %s chunk %s", file_path, chunk.index)
+                    failed_embedding = True
+                    continue
                 self._store_chunk(
                     {
                         "text": chunk.text,
@@ -239,8 +276,12 @@ class ObsidianIngestor:
                         "embedding": embedding,
                     }
                 )
+                inserted_chunks += 1
 
-            self.state_tracker.mark_ingested(file_path, mod_time, len(chunks))
+            if not failed_embedding:
+                self.state_tracker.mark_ingested(file_path, mod_time, inserted_chunks)
+            else:
+                logger.error("Embedding failures detected for %s; skipping state update", file_path)
             self._log_progress(index, total_to_process, start_time)
 
         stats = {

--- a/src/mnemosyne/aletheia/pdf_ingestor.py
+++ b/src/mnemosyne/aletheia/pdf_ingestor.py
@@ -68,7 +68,14 @@ class PDFIngestor:
         chunks = self.chunk_text(cleaned, chunk_size=500)
         metadata = self.extract_metadata(path)
         for idx, chunk in enumerate(chunks):
-            vector = self._safe_embed(chunk)
+            try:
+                vector = self.embedder(chunk)
+            except Exception as exc:
+                logger.error("Embedding failed for %s chunk %s: %s", path, idx, exc)
+                continue
+            if not vector:
+                logger.error("Embedding empty for %s chunk %s", path, idx)
+                continue
             props = {
                 "body": chunk,
                 "sourcePath": str(path),
@@ -215,13 +222,6 @@ class PDFIngestor:
         return data
 
     # ---------------------- Helpers ---------------------- #
-
-    def _safe_embed(self, text: str) -> list[float]:
-        try:
-            return self.embedder(text)
-        except Exception as exc:
-            logger.warning("Embedding failed, returning zero vector: %s", exc)
-            return [0.0] * DEFAULT_EMBED_DIM
 
     # ---------------------- Internal helpers ---------------------- #
 

--- a/tests/unit/test_ingestor_embedding_failures.py
+++ b/tests/unit/test_ingestor_embedding_failures.py
@@ -1,0 +1,134 @@
+"""Unit tests for ingestors when embeddings fail."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from unittest.mock import Mock, patch
+
+from mnemosyne.aletheia.email_ingest import EmailIngestConfig, EmailIngestor
+from mnemosyne.aletheia.models import Email
+from mnemosyne.aletheia.obsidian_ingestor import ObsidianIngestor
+from mnemosyne.aletheia.pdf_ingestor import PDFIngestor
+from mnemosyne.aletheia.text_chunker import TextChunk
+
+
+class _DummyState:
+    def is_ingested(self, *_args, **_kwargs):
+        return False
+
+    def mark_ingested(self, *_args, **_kwargs):
+        return None
+
+    def save(self):
+        return None
+
+
+def _fake_collection():
+    collection = Mock()
+    collection.data.insert = Mock()
+    return collection
+
+
+def _fake_client(collection):
+    client = Mock()
+    client.collections.get.return_value = collection
+    return client
+
+
+def test_pdf_ingestor_skips_insert_when_embedding_raises(tmp_path, caplog):
+    collection = _fake_collection()
+    client = _fake_client(collection)
+
+    with patch("mnemosyne.aletheia.pdf_ingestor.WeaviateSchemaManager.ensure_collection_exists"):
+        ingestor = PDFIngestor(
+            input_dir=str(tmp_path),
+            weaviate_client=client,
+            embedder=Mock(side_effect=ValueError("boom")),
+        )
+
+    pdf_path = tmp_path / "doc.pdf"
+    pdf_path.write_text("stub")
+
+    with (
+        patch.object(ingestor, "_extract_text", return_value="hello"),
+        patch.object(ingestor, "clean_text", return_value="hello"),
+        patch.object(ingestor, "chunk_text", return_value=["chunk"]),
+    ):
+        caplog.set_level(logging.ERROR)
+        ingestor.ingest_file(pdf_path)
+
+    assert collection.data.insert.call_count == 0
+    assert any("embedding" in record.message.lower() for record in caplog.records)
+
+
+def test_email_ingestor_skips_insert_when_embedding_empty(tmp_path, caplog):
+    collection = _fake_collection()
+    client = _fake_client(collection)
+    config = EmailIngestConfig(
+        source_dir=tmp_path,
+        chunking_strategy="recursive",
+        min_body_chars=1,
+    )
+
+    with patch("mnemosyne.aletheia.email_ingest.WeaviateSchemaManager.ensure_collection_exists"):
+        ingestor = EmailIngestor(config, client, embedder=Mock(return_value=[]))
+
+    ingestor.chunker = Mock()
+    ingestor.chunker.chunk.return_value = [
+        TextChunk(text="body", index=0, source_file="source.eml")
+    ]
+    ingestor.state = _DummyState()
+
+    email = Email(
+        subject="Test",
+        body="Body that is long enough for ingestion.",
+        sender="sender@example.com",
+        date="2025-01-01",
+        message_id="msg-1",
+        source_path="source.eml",
+        unique_id="unique-1",
+    )
+
+    caplog.set_level(logging.ERROR, logger="mnemosyne.aletheia.email_ingest")
+    summary = ingestor._ingest_emails([email])
+
+    assert collection.data.insert.call_count == 0
+    assert summary.total_stored == 0
+    assert any("embedding" in record.message.lower() for record in caplog.records)
+
+
+def test_obsidian_ingestor_skips_insert_when_embedding_none(tmp_path, caplog):
+    collection = _fake_collection()
+    client = _fake_client(collection)
+
+    with (
+        patch(
+            "mnemosyne.aletheia.obsidian_ingestor.WeaviateSchemaManager.ensure_collection_exists"
+        ),
+        patch(
+            "mnemosyne.aletheia.obsidian_ingestor.ChunkingStrategyFactory.create",
+            return_value=Mock(),
+        ),
+    ):
+        ingestor = ObsidianIngestor(
+            vault_path=str(tmp_path),
+            weaviate_client=client,
+            ollama_client=Mock(),
+            state_tracker=_DummyState(),
+        )
+
+    chunk = TextChunk(text="note", index=0, source_file="note.md")
+    mod_time = datetime.now(UTC)
+
+    with (
+        patch.object(ingestor, "_prepare_chunks_for_file", return_value=([chunk], mod_time)),
+        patch.object(ingestor, "_delete_existing_chunks"),
+    ):
+        ingestor._generate_embedding = Mock(return_value=None)
+        ingestor._store_chunk = Mock()
+        caplog.set_level(logging.ERROR)
+        ingestor.ingest_file(str(tmp_path / "note.md"))
+
+    assert ingestor._store_chunk.call_count == 0
+    assert any("embedding" in record.message.lower() for record in caplog.records)


### PR DESCRIPTION
## Summary
- skip PDF/email/Obsidian inserts when embeddings are empty/raise
- log embedding failures with source context and avoid marking state on failures
- add unit tests covering embedding failure handling
- add AGENTS guidance for Markdown issue formatting

## Issues
- Closes #102
- Closes #103

## Testing
- pytest tests/unit/test_ingestor_embedding_failures.py -v
