### PR TITLE
Chore: fix staging SOURCE_DIR path

### DIFF
--- a/.env.staging
+++ b/.env.staging
@@ -24,7 +24,7 @@ NEO4J_PASSWORD=CHANGE_ME
 
 OLLAMA_BASE_URL=http://host.docker.internal:11434
 
-SOURCE_DIR=/home/tgrytnes/projects/Mnemosyne/data/staging/emails
+SOURCE_DIR=/data/emails
 
 SCHEDULER_INTERVAL_HOURS=24
 N_CLUSTERS=50


### PR DESCRIPTION
## Summary
- set staging SOURCE_DIR to /data/emails so watcher paths resolve inside containers

## Testing
- not run (env-only change)
