### PR TITLE
Hotfix: serialize monitor escalation datetime

### DIFF
--- a/src/mnemosyne/argus/scout/monitor_agent.py
+++ b/src/mnemosyne/argus/scout/monitor_agent.py
@@ -427,6 +427,7 @@ class MonitorAgent:
         for proposal in rejected:
             discovery_id = proposal["discovery_id"]
             message_id = f"proposal_escalation:{discovery_id}"
+            detected_at = _serialize_datetime(proposal.get("detected_at"))
             payload = {
                 "type": "proposal_escalation",
                 "proposal_id": proposal["proposal_id"],
@@ -434,7 +435,7 @@ class MonitorAgent:
                 "discovery_job_key": proposal["discovery_job_key"],
                 "candidate_key": proposal["candidate_key"],
                 "confidence": proposal["confidence_score"],
-                "detected_at": proposal["detected_at"],
+                "detected_at": detected_at,
             }
             self._intent_queue.enqueue_intent(
                 intent_type="proposal_escalation",
@@ -494,3 +495,13 @@ def _parse_datetime(value: Any) -> datetime | None:
         except ValueError:
             return None
     return None
+
+
+def _serialize_datetime(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, str):
+        return value
+    return str(value)

--- a/tests/unit/test_monitor_agent.py
+++ b/tests/unit/test_monitor_agent.py
@@ -56,6 +56,25 @@ class _InMemoryIntentQueue:
         )
 
 
+class _JsonIntentQueue:
+    def __init__(self):
+        self.payloads: list[dict] = []
+
+    def enqueue_intent(
+        self,
+        intent_type: str,
+        payload: dict,
+        message_id: str,
+        originating_agent: str | None = None,
+        context_id: str | None = None,
+        expects_response: bool = False,
+    ) -> None:
+        import json
+
+        json.dumps(payload)
+        self.payloads.append(payload)
+
+
 class _InMemoryProposalQueue:
     def __init__(self):
         self._proposals: dict[str, dict] = {}
@@ -249,6 +268,33 @@ def test_monitor_escalation_records_intent():
     assert intent["originating_agent"] == "monitor"
     assert intent["context_id"] == f"discovery:{discovery.discovery_id}"
     assert intent["expects_response"] is False
+
+
+def test_monitor_escalation_payload_is_json_serializable():
+    discovery = _sample_discovery(confidence=0.95)
+    reader = _FakeDiscoveryReader([])
+    projects = _FakeProjectRepository(existing_ids=set())
+
+    proposal_queue = _InMemoryProposalQueue()
+    state_store = _InMemoryStateStore()
+    intent_queue = _JsonIntentQueue()
+
+    proposal_queue.upsert(discovery)
+    proposal_queue.update_status(discovery.discovery_id, "rejected")
+
+    agent = MonitorAgent(
+        discovery_reader=reader,
+        project_repository=projects,
+        proposal_queue=proposal_queue,
+        state_store=state_store,
+        intent_queue=intent_queue,
+        config=MonitorConfig(confidence_threshold=0.7),
+    )
+
+    agent.run()
+
+    assert intent_queue.payloads
+    assert isinstance(intent_queue.payloads[0]["detected_at"], str)
 
 
 def test_monitor_logs_summary_counts(caplog):


### PR DESCRIPTION
## Summary
- serialize detected_at in monitor escalation payloads
- add unit coverage to ensure escalation payloads are JSON-serializable

## Testing
- .venv/bin/pytest tests/unit/test_monitor_agent.py -v
