### PR TITLE
Hotfix: Hermes poller async Telegram client

### DIFF
--- a/src/mnemosyne/hermes/telegram_poller.py
+++ b/src/mnemosyne/hermes/telegram_poller.py
@@ -4,7 +4,11 @@ import json
 import time
 from collections.abc import Callable
 
-from mnemosyne.hermes.telegram_transport import TelegramOutboxConsumer, TelegramReplyRouter
+from mnemosyne.hermes.telegram_transport import (
+    TelegramOutboxConsumer,
+    TelegramReplyRouter,
+    _resolve_maybe_async,
+)
 
 
 class TelegramApiClient:
@@ -66,9 +70,11 @@ class TelegramOutboxPoller:
         self._consumer.deliver_pending(limit=self._send_limit)
 
     def poll_replies(self) -> None:
-        updates = self._client.get_updates(
-            offset=self._next_update_offset(),
-            timeout=self._reply_timeout_seconds,
+        updates = _resolve_maybe_async(
+            self._client.get_updates(
+                offset=self._next_update_offset(),
+                timeout=self._reply_timeout_seconds,
+            )
         )
         for update in updates:
             self._handle_update(update)

--- a/src/mnemosyne/hermes/telegram_transport.py
+++ b/src/mnemosyne/hermes/telegram_transport.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import asyncio
+import inspect
 from dataclasses import dataclass
+from typing import Any
 
 from mnemosyne.alexandria.message_outbox import MessageOutbox
 
@@ -37,12 +40,16 @@ class TelegramOutboxConsumer:
                 )
                 continue
             try:
-                message_id = self._client.send_message(
-                    chat_id=payload.chat_id,
-                    text=payload.text,
-                    buttons=payload.buttons,
-                    parse_mode=payload.parse_mode,
+                message_id = _resolve_maybe_async(
+                    self._client.send_message(
+                        chat_id=payload.chat_id,
+                        text=payload.text,
+                        buttons=payload.buttons,
+                        parse_mode=payload.parse_mode,
+                    )
                 )
+                if hasattr(message_id, "message_id"):
+                    message_id = message_id.message_id
                 self._outbox.mark_delivered(
                     message_id=row.message_id,
                     chat_id=payload.chat_id,
@@ -85,3 +92,15 @@ class TelegramReplyRouter:
             response_json=parsed_response,
         )
         return agent is not None
+
+
+def _resolve_maybe_async(result: Any) -> Any:
+    if not inspect.isawaitable(result):
+        return result
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(result)
+    if loop.is_running():
+        raise RuntimeError("Async Telegram client requires a non-running event loop.")
+    return loop.run_until_complete(result)

--- a/tests/unit/hermes/test_telegram_poller.py
+++ b/tests/unit/hermes/test_telegram_poller.py
@@ -93,3 +93,37 @@ def test_poller_records_discovery_decision(tmp_path):
 
     row = store.get_by_message_id("msg-approval")
     assert row.response == {"decision": "approve"}
+
+
+def test_poller_handles_async_get_updates(tmp_path):
+    from mnemosyne.hermes.telegram_poller import TelegramOutboxPoller
+
+    class AsyncTelegramClient:
+        async def get_updates(self, *, offset=None, timeout=None):
+            return [
+                FakeUpdate(
+                    FakeMessage(
+                        chat_id="chat-3",
+                        text="3",
+                        reply_to_message_id=920,
+                        message_id=921,
+                    )
+                )
+            ]
+
+    store = _make_store(tmp_path)
+    store.enqueue(
+        message_type="question",
+        payload={"chat_id": "chat-3", "text": "Urgency?", "question_type": "urgency"},
+        message_id="msg-urgency",
+        expects_response=True,
+        originating_agent="project_manager",
+        context_id="project:3",
+    )
+    store.mark_delivered(message_id="msg-urgency", chat_id="chat-3", telegram_message_id=920)
+
+    poller = TelegramOutboxPoller(store, AsyncTelegramClient())
+    poller.poll_replies()
+
+    row = store.get_by_message_id("msg-urgency")
+    assert row.response == {"question_type": "urgency", "value": 3}

--- a/tests/unit/hermes/test_telegram_transport.py
+++ b/tests/unit/hermes/test_telegram_transport.py
@@ -194,3 +194,27 @@ def test_consumer_uses_default_chat_id_when_missing(tmp_path):
     row = store.get_by_message_id("msg-default-chat")
     assert row.status == "delivered"
     assert client.sent[0]["chat_id"] == "chat-default"
+
+
+def test_consumer_handles_async_send_message(tmp_path):
+    from mnemosyne.hermes.telegram_transport import TelegramOutboxConsumer
+
+    class AsyncTelegramClient:
+        async def send_message(self, *, chat_id: str, text: str, buttons: list, parse_mode):
+            return 4242
+
+    store = _make_store(tmp_path)
+    store.enqueue(
+        message_type="notification",
+        payload={"chat_id": "chat-async", "text": "Hello", "buttons": [], "parse_mode": None},
+        message_id="msg-async",
+        expects_response=False,
+        originating_agent="project_manager",
+        context_id="project:async",
+    )
+
+    consumer = TelegramOutboxConsumer(store, AsyncTelegramClient())
+    consumer.deliver_pending(limit=5)
+
+    row = store.get_by_message_id("msg-async")
+    assert row.status == "delivered"


### PR DESCRIPTION
Fixes Hermes poller crash with python-telegram-bot async API.

- Resolve awaitables for send_message/get_updates.
- Supports Message objects returned by Bot.send_message.
- Adds unit coverage for async client behavior.

Tests:
- .venv/bin/black src tests
- .venv/bin/ruff check src tests
- .venv/bin/pytest tests/unit/hermes/test_telegram_transport.py tests/unit/hermes/test_telegram_poller.py -v