### PR TITLE
Hotfix: Hermes poller event loop reuse

### DIFF
--- a/src/mnemosyne/hermes/telegram_transport.py
+++ b/src/mnemosyne/hermes/telegram_transport.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import threading
 from dataclasses import dataclass
 from typing import Any
 
@@ -94,13 +95,36 @@ class TelegramReplyRouter:
         return agent is not None
 
 
+class _AsyncRunner:
+    def __init__(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._run_loop, daemon=True)
+        self._thread.start()
+
+    def _run_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+    def run(self, coro: Any) -> Any:
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return future.result()
+
+    def is_closed(self) -> bool:
+        return self._loop.is_closed()
+
+
+_ASYNC_RUNNER: _AsyncRunner | None = None
+
+
+def _get_async_runner() -> _AsyncRunner:
+    global _ASYNC_RUNNER
+    if _ASYNC_RUNNER is None or _ASYNC_RUNNER.is_closed():
+        _ASYNC_RUNNER = _AsyncRunner()
+    return _ASYNC_RUNNER
+
+
 def _resolve_maybe_async(result: Any) -> Any:
     if not inspect.isawaitable(result):
         return result
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(result)
-    if loop.is_running():
-        raise RuntimeError("Async Telegram client requires a non-running event loop.")
-    return loop.run_until_complete(result)
+    runner = _get_async_runner()
+    return runner.run(result)

--- a/tests/unit/hermes/test_telegram_poller.py
+++ b/tests/unit/hermes/test_telegram_poller.py
@@ -99,7 +99,21 @@ def test_poller_handles_async_get_updates(tmp_path):
     from mnemosyne.hermes.telegram_poller import TelegramOutboxPoller
 
     class AsyncTelegramClient:
+        def __init__(self) -> None:
+            self.calls = 0
+            self.loop = None
+
         async def get_updates(self, *, offset=None, timeout=None):
+            import asyncio
+
+            loop = asyncio.get_running_loop()
+            if self.loop is None:
+                self.loop = loop
+            elif self.loop is not loop:
+                raise RuntimeError("loop changed")
+            self.calls += 1
+            if self.calls > 1:
+                return []
             return [
                 FakeUpdate(
                     FakeMessage(
@@ -123,6 +137,7 @@ def test_poller_handles_async_get_updates(tmp_path):
     store.mark_delivered(message_id="msg-urgency", chat_id="chat-3", telegram_message_id=920)
 
     poller = TelegramOutboxPoller(store, AsyncTelegramClient())
+    poller.poll_replies()
     poller.poll_replies()
 
     row = store.get_by_message_id("msg-urgency")


### PR DESCRIPTION
Fixes Hermes poller crash when using python-telegram-bot async API by keeping a persistent background event loop for all async calls.

- Replaces asyncio.run with a long-lived async runner.
- Prevents 'Event loop is closed' errors in long-lived poller.
- Extends async poller test to ensure a stable loop across multiple polls.

Tests:
- .venv/bin/black src tests
- .venv/bin/ruff check src tests
- .venv/bin/pytest tests/unit/hermes/test_telegram_transport.py tests/unit/hermes/test_telegram_poller.py -v