### PR TITLE
Hotfix: await async Telegram send_message

### DIFF
--- a/src/mnemosyne/hermes/telegram_poller.py
+++ b/src/mnemosyne/hermes/telegram_poller.py
@@ -28,11 +28,13 @@ class TelegramApiClient:
         parse_mode: str | None,
     ) -> int:
         reply_markup = _build_reply_markup(buttons)
-        message = self._bot.send_message(
-            chat_id=chat_id,
-            text=text,
-            reply_markup=reply_markup,
-            parse_mode=parse_mode,
+        message = _resolve_maybe_async(
+            self._bot.send_message(
+                chat_id=chat_id,
+                text=text,
+                reply_markup=reply_markup,
+                parse_mode=parse_mode,
+            )
         )
         return message.message_id
 

--- a/tests/unit/hermes/test_telegram_poller.py
+++ b/tests/unit/hermes/test_telegram_poller.py
@@ -142,3 +142,35 @@ def test_poller_handles_async_get_updates(tmp_path):
 
     row = store.get_by_message_id("msg-urgency")
     assert row.response == {"question_type": "urgency", "value": 3}
+
+
+def test_api_client_awaits_async_send_message(monkeypatch):
+    import sys
+    import types
+
+    from mnemosyne.hermes.telegram_poller import TelegramApiClient
+
+    class FakeMessage:
+        def __init__(self, message_id: int):
+            self.message_id = message_id
+
+    class FakeBot:
+        def __init__(self, token: str):
+            self.token = token
+
+        async def send_message(self, **_kwargs):
+            return FakeMessage(123)
+
+    fake_module = types.ModuleType("telegram")
+    fake_module.Bot = FakeBot
+    monkeypatch.setitem(sys.modules, "telegram", fake_module)
+
+    client = TelegramApiClient(token="token")
+    message_id = client.send_message(
+        chat_id="chat-1",
+        text="Hello",
+        buttons=[],
+        parse_mode=None,
+    )
+
+    assert message_id == 123


### PR DESCRIPTION
Closes #115

## Summary
- await/resolve async Bot.send_message before reading message_id
- add unit test for async send_message in TelegramApiClient

## Testing
- `PYTHONPATH=src .venv/bin/pytest tests/unit/hermes/test_telegram_poller.py -k "api_client_awaits_async_send_message"` (passes; warning: unknown config option asyncio_mode)