### PR TITLE
Fix CLI module entrypoints for hermes and scheduler

### DIFF
--- a/src/mnemosyne/cli/hermes.py
+++ b/src/mnemosyne/cli/hermes.py
@@ -137,3 +137,7 @@ def hermes_cli(once: bool):
     signal.signal(signal.SIGINT, _handle_signal)
 
     run_poller(once=once)
+
+
+if __name__ == "__main__":
+    hermes_cli()

--- a/src/mnemosyne/cli/scheduler.py
+++ b/src/mnemosyne/cli/scheduler.py
@@ -764,3 +764,7 @@ def scheduler_cli(once: bool):
 
     logger.info("Scheduler shutting down gracefully")
     sys.exit(0)
+
+
+if __name__ == "__main__":
+    scheduler_cli()

--- a/tests/e2e/test_cli_entrypoints_e2e.py
+++ b/tests/e2e/test_cli_entrypoints_e2e.py
@@ -1,0 +1,47 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _run_module_help(module: str) -> subprocess.CompletedProcess[str]:
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join([str(repo_root / "src"), env.get("PYTHONPATH", "")]).strip(
+        os.pathsep
+    )
+
+    return subprocess.run(
+        [sys.executable, "-m", module, "--help"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+@pytest.mark.e2e
+@pytest.mark.weaviate
+def test_scheduler_entrypoint_with_real_weaviate(weaviate_client, clean_weaviate_collection):
+    import weaviate.classes as wvc
+
+    collection = weaviate_client.collections.create(
+        name="TestCollection",
+        vector_config=wvc.config.Configure.Vectors.self_provided(),
+        properties=[
+            wvc.config.Property(name="text", data_type=wvc.config.DataType.TEXT),
+        ],
+    )
+    collection.data.insert(
+        properties={"text": "entrypoint smoke"},
+        vector={"default": [0.0, 0.0, 0.0]},
+    )
+
+    response = collection.query.fetch_objects(limit=1)
+    assert response.objects
+
+    result = _run_module_help("mnemosyne.cli.scheduler")
+    assert result.returncode == 0, result.stderr
+    assert "Run a single scheduler cycle and exit." in result.stdout

--- a/tests/unit/test_cli_module_entrypoints.py
+++ b/tests/unit/test_cli_module_entrypoints.py
@@ -1,0 +1,37 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _run_module_help(module: str) -> subprocess.CompletedProcess[str]:
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join([str(repo_root / "src"), env.get("PYTHONPATH", "")]).strip(
+        os.pathsep
+    )
+
+    return subprocess.run(
+        [sys.executable, "-m", module, "--help"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("module", "expected"),
+    [
+        ("mnemosyne.cli.hermes", "Run a single delivery + reply poll cycle and exit."),
+        ("mnemosyne.cli.scheduler", "Run a single scheduler cycle and exit."),
+    ],
+)
+def test_cli_module_help_includes_options(module: str, expected: str) -> None:
+    result = _run_module_help(module)
+
+    assert result.returncode == 0, result.stderr
+    assert expected in result.stdout


### PR DESCRIPTION
## Summary
- add explicit module entrypoints so `python -m mnemosyne.cli.{hermes,scheduler}` executes the Click CLI
- add unit tests for `--help` module invocation
- add E2E smoke test with real Weaviate before checking scheduler entrypoint

## Testing
- `./.venv/bin/pytest tests/unit/test_cli_module_entrypoints.py`
- `./.venv/bin/pytest tests/e2e/test_cli_entrypoints_e2e.py`
- `./.venv/bin/ruff check src/mnemosyne/cli/hermes.py src/mnemosyne/cli/scheduler.py tests/unit/test_cli_module_entrypoints.py tests/e2e/test_cli_entrypoints_e2e.py`
- `./.venv/bin/black src/mnemosyne/cli/hermes.py src/mnemosyne/cli/scheduler.py tests/unit/test_cli_module_entrypoints.py tests/e2e/test_cli_entrypoints_e2e.py`

Closes #121
