### PR TITLE
feat: add LM Studio as LLM and embedding provider

### DIFF
--- a/src/mnemosyne/config/providers.py
+++ b/src/mnemosyne/config/providers.py
@@ -51,6 +51,19 @@ class ProviderConfig:
     vllm_llm_model: str = field(default_factory=lambda: os.getenv("VLLM_LLM_MODEL", ""))
     vllm_timeout: float = field(default_factory=lambda: float(os.getenv("VLLM_TIMEOUT", "30.0")))
 
+    # LM Studio settings
+    lmstudio_base_url: str = field(
+        default_factory=lambda: os.getenv("LMSTUDIO_BASE_URL", "http://localhost:1234")
+    )
+    lmstudio_api_key: str | None = field(default_factory=lambda: os.getenv("LMSTUDIO_API_KEY"))
+    lmstudio_llm_model: str = field(default_factory=lambda: os.getenv("LMSTUDIO_LLM_MODEL", ""))
+    lmstudio_embedding_model: str = field(
+        default_factory=lambda: os.getenv("LMSTUDIO_EMBEDDING_MODEL", "")
+    )
+    lmstudio_timeout: float = field(
+        default_factory=lambda: float(os.getenv("LMSTUDIO_TIMEOUT", "30.0"))
+    )
+
     def __post_init__(self):
         if self.llm_provider is None:
             if self.llm_profile == "local":

--- a/src/mnemosyne/providers/factory.py
+++ b/src/mnemosyne/providers/factory.py
@@ -2,6 +2,7 @@ from mnemosyne.config.providers import ProviderConfig
 from mnemosyne.providers.base import EmbeddingProvider, LLMProvider
 from mnemosyne.providers.fastapi import FastAPIEmbeddingProvider, FastAPILLMProvider
 from mnemosyne.providers.groq import GroqLLMProvider
+from mnemosyne.providers.lmstudio import LMStudioEmbeddingProvider, LMStudioLLMProvider
 from mnemosyne.providers.ollama import OllamaEmbeddingProvider, OllamaLLMProvider
 from mnemosyne.providers.vllm import VLLMLLMProvider
 
@@ -13,6 +14,7 @@ class LLMProviderFactory:
         "groq": GroqLLMProvider,
         "fastapi": FastAPILLMProvider,
         "vllm": VLLMLLMProvider,
+        "lmstudio": LMStudioLLMProvider,
     }
 
     @classmethod
@@ -31,6 +33,7 @@ class EmbeddingProviderFactory:
     _provider_classes: dict[str, type[EmbeddingProvider]] = {
         "ollama": OllamaEmbeddingProvider,
         "fastapi": FastAPIEmbeddingProvider,
+        "lmstudio": LMStudioEmbeddingProvider,
     }
 
     @classmethod

--- a/src/mnemosyne/providers/lmstudio.py
+++ b/src/mnemosyne/providers/lmstudio.py
@@ -1,0 +1,121 @@
+"""LM Studio provider implementation.
+
+LM Studio exposes an OpenAI-compatible API for local LLM inference.
+Supports both chat completions and embeddings.
+"""
+
+import logging
+from typing import Any
+
+import requests
+
+from mnemosyne.config.providers import ProviderConfig
+from mnemosyne.providers.base import EmbeddingProvider, LLMProvider
+
+logger = logging.getLogger(__name__)
+
+
+class LMStudioLLMProvider(LLMProvider):
+    """LLM provider for LM Studio using OpenAI-compatible API."""
+
+    def __init__(self, config: ProviderConfig):
+        self.config = config
+
+    def supports_structured_output(self) -> bool:
+        """LM Studio supports structured JSON output via response_format."""
+        return True
+
+    def generate(
+        self,
+        model: str,
+        prompt: str,
+        format: str | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        url = f"{self.config.lmstudio_base_url}/v1/chat/completions"
+        model_id = model or self.config.lmstudio_llm_model
+        if not model_id:
+            raise ValueError("LM Studio model is required (set LMSTUDIO_LLM_MODEL or pass model).")
+
+        payload: dict[str, Any] = {
+            "model": model_id,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+
+        if options:
+            for key in ("temperature", "top_p", "max_tokens", "stream", "seed", "stop"):
+                if key in options:
+                    payload[key] = options[key]
+
+        # Handle JSON schema for structured output
+        if options and "json_schema" in options:
+            schema = options["json_schema"]
+            payload["response_format"] = {
+                "type": "json_schema",
+                "json_schema": schema,
+            }
+        elif format == "json":
+            payload["response_format"] = {"type": "json_object"}
+
+        headers: dict[str, str] | None = None
+        if self.config.lmstudio_api_key:
+            headers = {"Authorization": f"Bearer {self.config.lmstudio_api_key}"}
+
+        response = requests.post(
+            url,
+            headers=headers,
+            json=payload,
+            timeout=self.config.lmstudio_timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+        choices = data.get("choices", [])
+        message = choices[0].get("message", {}) if choices else {}
+        content = message.get("content", "")
+        return {"response": content, "raw": data}
+
+
+class LMStudioEmbeddingProvider(EmbeddingProvider):
+    """Embedding provider for LM Studio using OpenAI-compatible API."""
+
+    def __init__(self, config: ProviderConfig):
+        self.config = config
+
+    def embed(self, model: str, text: str) -> list[float]:
+        url = f"{self.config.lmstudio_base_url}/v1/embeddings"
+        model_id = model or self.config.lmstudio_embedding_model
+
+        payload = {
+            "model": model_id,
+            "input": text,
+        }
+
+        headers: dict[str, str] | None = None
+        if self.config.lmstudio_api_key:
+            headers = {"Authorization": f"Bearer {self.config.lmstudio_api_key}"}
+
+        response = requests.post(
+            url,
+            headers=headers,
+            json=payload,
+            timeout=self.config.lmstudio_timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data["data"][0]["embedding"]
+
+    def embed_late(
+        self,
+        model: str,
+        text: str,
+        chunk_spans: list[tuple[int, int]],
+        options: dict[str, Any] | None = None,
+    ) -> list[list[float]]:
+        raise NotImplementedError("Late chunking is not supported by LM Studio embeddings.")
+
+    def embed_query(self, model: str, text: str) -> list[float]:
+        """Return an embedding for query text.
+
+        LM Studio does not support query adapters, so this delegates to embed().
+        """
+        return self.embed(model=model, text=text)

--- a/tests/unit/test_lmstudio_provider.py
+++ b/tests/unit/test_lmstudio_provider.py
@@ -1,0 +1,295 @@
+"""Unit tests for LM Studio provider.
+
+Tests for LMStudioLLMProvider and LMStudioEmbeddingProvider.
+Following TDD: these tests are written before the implementation.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mnemosyne.config.providers import ProviderConfig
+from mnemosyne.providers.lmstudio import LMStudioEmbeddingProvider, LMStudioLLMProvider
+
+
+class TestLMStudioLLMProvider:
+    """Tests for LMStudioLLMProvider."""
+
+    def test_generate_basic(self):
+        """Should generate a response using OpenAI-compatible API."""
+        config = ProviderConfig(
+            llm_provider="lmstudio",
+            lmstudio_base_url="http://192.168.178.212:1234",
+            lmstudio_llm_model="qwen/qwen3-4b-2507",
+        )
+        provider = LMStudioLLMProvider(config)
+
+        with patch("mnemosyne.providers.lmstudio.requests.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"choices": [{"message": {"content": "Hello!"}}]}
+            mock_post.return_value = mock_response
+
+            response = provider.generate(
+                model="qwen/qwen3-4b-2507",
+                prompt="Say hello",
+            )
+
+            assert response["response"] == "Hello!"
+            mock_post.assert_called_with(
+                "http://192.168.178.212:1234/v1/chat/completions",
+                headers=None,
+                json={
+                    "model": "qwen/qwen3-4b-2507",
+                    "messages": [{"role": "user", "content": "Say hello"}],
+                },
+                timeout=30.0,
+            )
+
+    def test_generate_with_options(self):
+        """Should pass temperature, top_p, max_tokens, and other options."""
+        config = ProviderConfig(
+            llm_provider="lmstudio",
+            lmstudio_base_url="http://localhost:1234",
+            lmstudio_llm_model="test-model",
+        )
+        provider = LMStudioLLMProvider(config)
+
+        with patch("mnemosyne.providers.lmstudio.requests.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"choices": [{"message": {"content": "response"}}]}
+            mock_post.return_value = mock_response
+
+            provider.generate(
+                model="test-model",
+                prompt="test",
+                options={"temperature": 0.7, "top_p": 0.9, "max_tokens": 100},
+            )
+
+            call_args = mock_post.call_args
+            payload = call_args.kwargs["json"]
+            assert payload["temperature"] == 0.7
+            assert payload["top_p"] == 0.9
+            assert payload["max_tokens"] == 100
+
+    def test_generate_uses_default_model(self):
+        """Should use default model from config when model param is empty."""
+        config = ProviderConfig(
+            llm_provider="lmstudio",
+            lmstudio_base_url="http://localhost:1234",
+            lmstudio_llm_model="default-model",
+        )
+        provider = LMStudioLLMProvider(config)
+
+        with patch("mnemosyne.providers.lmstudio.requests.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
+            mock_post.return_value = mock_response
+
+            provider.generate(model="", prompt="test")
+
+            call_args = mock_post.call_args
+            payload = call_args.kwargs["json"]
+            assert payload["model"] == "default-model"
+
+    def test_supports_structured_output(self):
+        """Should return True for supports_structured_output."""
+        config = ProviderConfig(
+            llm_provider="lmstudio",
+            lmstudio_base_url="http://localhost:1234",
+            lmstudio_llm_model="test-model",
+        )
+        provider = LMStudioLLMProvider(config)
+        assert provider.supports_structured_output() is True
+
+    def test_generate_with_json_schema(self):
+        """Should send json_schema via response_format for strict JSON."""
+        config = ProviderConfig(
+            llm_provider="lmstudio",
+            lmstudio_base_url="http://localhost:1234",
+            lmstudio_llm_model="test-model",
+        )
+        provider = LMStudioLLMProvider(config)
+
+        schema = {
+            "name": "test_schema",
+            "schema": {
+                "type": "object",
+                "properties": {"boundaries": {"type": "array", "items": {"type": "integer"}}},
+                "required": ["boundaries"],
+                "additionalProperties": False,
+            },
+        }
+
+        with patch("mnemosyne.providers.lmstudio.requests.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "choices": [{"message": {"content": '{"boundaries": [0, 100, 200]}'}}]
+            }
+            mock_post.return_value = mock_response
+
+            response = provider.generate(
+                model="test-model",
+                prompt="Return boundaries",
+                format="json",
+                options={"temperature": 0.2, "json_schema": schema},
+            )
+
+            assert response["response"] == '{"boundaries": [0, 100, 200]}'
+            call_args = mock_post.call_args
+            payload = call_args.kwargs["json"]
+            # LM Studio uses OpenAI-compatible response_format with json_schema
+            assert "response_format" in payload
+            assert payload["response_format"]["type"] == "json_schema"
+            assert payload["response_format"]["json_schema"] == schema
+
+    def test_generate_with_basic_json_format(self):
+        """Should use json_object response_format when format='json' without schema."""
+        config = ProviderConfig(
+            llm_provider="lmstudio",
+            lmstudio_base_url="http://localhost:1234",
+            lmstudio_llm_model="test-model",
+        )
+        provider = LMStudioLLMProvider(config)
+
+        with patch("mnemosyne.providers.lmstudio.requests.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "choices": [{"message": {"content": '{"key": "value"}'}}]
+            }
+            mock_post.return_value = mock_response
+
+            provider.generate(
+                model="test-model",
+                prompt="Return JSON",
+                format="json",
+            )
+
+            call_args = mock_post.call_args
+            payload = call_args.kwargs["json"]
+            assert payload["response_format"] == {"type": "json_object"}
+
+    def test_generate_raises_on_missing_model(self):
+        """Should raise ValueError when no model specified and no default."""
+        config = ProviderConfig(
+            llm_provider="lmstudio",
+            lmstudio_base_url="http://localhost:1234",
+            lmstudio_llm_model="",
+        )
+        provider = LMStudioLLMProvider(config)
+
+        with pytest.raises(ValueError, match="model is required"):
+            provider.generate(model="", prompt="test")
+
+
+class TestLMStudioEmbeddingProvider:
+    """Tests for LMStudioEmbeddingProvider."""
+
+    def test_embed_basic(self):
+        """Should generate embeddings using OpenAI-compatible API."""
+        config = ProviderConfig(
+            embedding_provider="lmstudio",
+            lmstudio_base_url="http://192.168.178.212:1234",
+            lmstudio_embedding_model="text-embedding-nomic-embed-text-v1.5",
+        )
+        provider = LMStudioEmbeddingProvider(config)
+
+        with patch("mnemosyne.providers.lmstudio.requests.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"data": [{"embedding": [0.1, 0.2, 0.3, 0.4]}]}
+            mock_post.return_value = mock_response
+
+            embedding = provider.embed(
+                model="text-embedding-nomic-embed-text-v1.5",
+                text="Hello world",
+            )
+
+            assert embedding == [0.1, 0.2, 0.3, 0.4]
+            mock_post.assert_called_with(
+                "http://192.168.178.212:1234/v1/embeddings",
+                headers=None,
+                json={
+                    "model": "text-embedding-nomic-embed-text-v1.5",
+                    "input": "Hello world",
+                },
+                timeout=30.0,
+            )
+
+    def test_embed_uses_default_model(self):
+        """Should use default model from config when model param is empty."""
+        config = ProviderConfig(
+            embedding_provider="lmstudio",
+            lmstudio_base_url="http://localhost:1234",
+            lmstudio_embedding_model="default-embedding-model",
+        )
+        provider = LMStudioEmbeddingProvider(config)
+
+        with patch("mnemosyne.providers.lmstudio.requests.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"data": [{"embedding": [1.0, 2.0]}]}
+            mock_post.return_value = mock_response
+
+            provider.embed(model="", text="test")
+
+            call_args = mock_post.call_args
+            payload = call_args.kwargs["json"]
+            assert payload["model"] == "default-embedding-model"
+
+    def test_embed_query(self):
+        """Should call embed for query text (no special adapter support)."""
+        config = ProviderConfig(
+            embedding_provider="lmstudio",
+            lmstudio_base_url="http://localhost:1234",
+            lmstudio_embedding_model="embedding-model",
+        )
+        provider = LMStudioEmbeddingProvider(config)
+
+        with patch("mnemosyne.providers.lmstudio.requests.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"data": [{"embedding": [0.5, 0.6]}]}
+            mock_post.return_value = mock_response
+
+            embedding = provider.embed_query(model="", text="query text")
+
+            assert embedding == [0.5, 0.6]
+
+    def test_embed_late_not_implemented(self):
+        """Should raise NotImplementedError for late chunking."""
+        config = ProviderConfig(
+            embedding_provider="lmstudio",
+            lmstudio_base_url="http://localhost:1234",
+            lmstudio_embedding_model="embedding-model",
+        )
+        provider = LMStudioEmbeddingProvider(config)
+
+        with pytest.raises(NotImplementedError):
+            provider.embed_late(
+                model="embedding-model",
+                text="some text",
+                chunk_spans=[(0, 10), (10, 20)],
+            )
+
+
+class TestLMStudioProviderFactory:
+    """Tests for factory registration of LM Studio providers."""
+
+    def test_create_lmstudio_llm_provider(self):
+        """Should create LMStudioLLMProvider via factory."""
+        from mnemosyne.providers.factory import create_llm_provider
+
+        config = ProviderConfig(
+            llm_provider="lmstudio",
+            lmstudio_base_url="http://localhost:1234",
+        )
+        provider = create_llm_provider(config)
+        assert isinstance(provider, LMStudioLLMProvider)
+
+    def test_create_lmstudio_embedding_provider(self):
+        """Should create LMStudioEmbeddingProvider via factory."""
+        from mnemosyne.providers.factory import create_embedding_provider
+
+        config = ProviderConfig(
+            embedding_provider="lmstudio",
+            lmstudio_base_url="http://localhost:1234",
+        )
+        provider = create_embedding_provider(config)
+        assert isinstance(provider, LMStudioEmbeddingProvider)


### PR DESCRIPTION
## Summary

- Add `LMStudioLLMProvider` with structured JSON output support via `response_format`
- Add `LMStudioEmbeddingProvider` for embeddings via OpenAI-compatible API
- Add configuration options: `LMSTUDIO_BASE_URL`, `LMSTUDIO_LLM_MODEL`, `LMSTUDIO_EMBEDDING_MODEL`, `LMSTUDIO_API_KEY`, `LMSTUDIO_TIMEOUT`
- Register providers in `LLMProviderFactory` and `EmbeddingProviderFactory`

## Test plan

- [x] Unit tests for `LMStudioLLMProvider` (7 tests)
- [x] Unit tests for `LMStudioEmbeddingProvider` (4 tests)
- [x] Factory integration tests (2 tests)
- [x] All 13 new tests pass
- [x] All 29 provider-related tests pass
- [x] Black and Ruff checks pass

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)